### PR TITLE
docs: structure improvements and new chapters

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,33 @@
+Contributing
+============
+
+Issues
+------
+
+Bug reports, feature requests, and other contributions are welcome. If you find
+a demonstrable problem that is caused by the REANA code, please:
+
+1. Search for `already reported problems
+   <https://github.com/reanahub/reana-resources-k8s/issues>`_.
+2. Check if the issue has been fixed or is still reproducible on the
+   latest `master` branch.
+3. Create an issue, ideally with **a test case**.
+
+Pull requests
+-------------
+
+If you create a feature branch, you can run the tests to ensure that everything
+is operating correctly:
+
+.. code-block:: console
+
+    $ ./run-tests.sh
+
+Each pull request should preserve or increase code coverage.
+
+Kanban
+------
+
+We are using Kanban technique for keeping track of ongoing tasks. Please see our
+`Kanban board <https://waffle.io/reanahub/reana>`_ and look for issues that are
+labelled as "ready for work".

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,1 @@
+.. include:: ../CONTRIBUTING.rst

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -1,0 +1,4 @@
+Getting started
+===============
+
+FIXME

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,9 @@
    :numbered:
    :maxdepth: 2
 
-   usage
+   introduction
+   gettingstarted
+   contributing
    changes
    license
    authors

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,0 +1,17 @@
+Introduction
+============
+
+About
+-----
+
+REANA-Resources-K8s is a component of the `REANA <http://reanahub.io/>`_ system.
+It takes care of managing `Kubernetes <https://kubernetes.io/>`_ resources.
+Please see the `general REANA documentation <http://reana.readthedocs.io/>`_ if
+you would like to know more about the use of this component within the wider
+REANA framework.
+
+Features
+--------
+
+- manage computing cloud resources
+- support for `Kubernetes <https://kubernetes.io/>`_ workflows

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,16 +18,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-include COPYING
-include *.rst
-include *.sh
-include pytest.ini
-recursive-include docs *.py
-recursive-include docs *.png
-recursive-include docs *.rst
-recursive-include docs *.txt
-recursive-include tests *.py
-recursive-include deployments *.yaml
-recursive-include namespaces *.yaml
-recursive-include resourcequotas *.yaml
-recursive-include services *.yaml
+-e .[all]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,4 +1,0 @@
-Usage
-=====
-
-FIXME


### PR DESCRIPTION
* Adds more documentation chapters (Introduction, Getting started,
  Contributing).

* Adds `docs/requirements.txt` so that ReadTheDocs can install all the
  prerequisites for building the autodoc parts of the documentation.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>