### PR TITLE
docs: impersonal Getting Started example

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -11,6 +11,16 @@ or use development version:
 
 .. code-block:: console
 
+   $ mkvirtualenv reana-resources-k8s
+   Using base prefix '/usr'
+   New python executable in $HOME/.virtualenvs/test/bin/python3
+   Also creating executable in $HOME/.virtualenvs/test/bin/python
+   Installing setuptools, pip, wheel...done.
+   virtualenvwrapper.user_scripts creating $HOME/.virtualenvs/test/bin/predeactivate
+   virtualenvwrapper.user_scripts creating $HOME/.virtualenvs/test/bin/postdeactivate
+   virtualenvwrapper.user_scripts creating $HOME/.virtualenvs/test/bin/preactivate
+   virtualenvwrapper.user_scripts creating $HOME/.virtualenvs/test/bin/postactivate
+   virtualenvwrapper.user_scripts creating $HOME/.virtualenvs/test/bin/get_env_details
    $ git clone https://github.com/reanahub/reana-resources-k8s.git
    Cloning into 'reana-resources-k8s'...
    remote: Counting objects: 131, done.
@@ -20,41 +30,48 @@ or use development version:
    Checking connectivity... done.
    $ cd reana-resources-k8s
    $ pip install .
-   Processing /home/rodrigdi/reanahub-forks/reana-resources-k8s
-     Requirement already satisfied (use --upgrade to upgrade): reana-resources-k8s==0.0.1.dev20170123 from file:///home/rodrigdi/reanahub-forks/reana-resources-k8s in /home/rodrigdi/.virtualenvs/reana-resources-k8s/lib/python3.5/site-packages/reana_resources_k8s-0.0.1.dev20170123-py3.5.egg
+   Processing $HOME/private/src/reana-resources-k8s
+   Collecting jinja2-cli>=0.6.0 (from reana-resources-k8s==0.0.1.dev20170123)
+     Using cached jinja2_cli-0.6.0-py2.py3-none-any.whl
+   Collecting PyYAML>=3.12 (from reana-resources-k8s==0.0.1.dev20170123)
+   Collecting jinja2 (from jinja2-cli>=0.6.0->reana-resources-k8s==0.0.1.dev20170123)
+     Using cached Jinja2-2.9.5-py2.py3-none-any.whl
+   Collecting MarkupSafe>=0.23 (from jinja2->jinja2-cli>=0.6.0->reana-resources-k8s==0.0.1.dev20170123)
    Building wheels for collected packages: reana-resources-k8s
      Running setup.py bdist_wheel for reana-resources-k8s ... done
-     Stored in directory: /home/rodrigdi/.cache/pip/wheels/c7/22/44/782e373fa02c011646424f7830a9273af9b4a59970610e1255
+     Stored in directory: $HOME/.cache/pip/wheels/e0/37/f6/aae65584a32d4d0918c0332d67e75bf7946c5ce641752efcd4
    Successfully built reana-resources-k8s
+   Installing collected packages: MarkupSafe, jinja2, jinja2-cli, PyYAML, reana-resources-k8s
+   Successfully installed MarkupSafe-1.0 PyYAML-3.12 jinja2-2.9.5 jinja2-cli-0.6.0 reana-resources-k8s-0.0.1.dev20170123
 
 Second, you can build resource manifests by doing:
 
 .. code-block:: console
 
    $ reana-resources-k8s build-manifests
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/job-controller.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/message-broker.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/storage-admin.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/yadage-alice-worker.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/yadage-atlas-worker.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/yadage-cms-worker.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/yadage-lhcb-worker.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/workflow-controller.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/workflow-monitor.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/deployments/zeromq-msg-proxy.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/namespaces/alice.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/namespaces/atlas.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/namespaces/cms.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/namespaces/lhcb.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/resourcequotas/alice-quota.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/resourcequotas/atlas-quota.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/resourcequotas/cms-quota.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/resourcequotas/lhcb-quota.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/services/job-controller.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/services/message-broker.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/services/workflow-controller.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/services/workflow-monitor.yaml
-   Created -> /home/reanauser/reana/configuration-manifests/services/zeromq-msg-proxy.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/job-controller.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/message-broker.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/storage-admin.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/yadage-alice-worker.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/yadage-atlas-worker.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/yadage-cms-worker.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/yadage-lhcb-worker.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/workflow-controller.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/workflow-monitor.yaml
+   Created -> $HOME/reana/configuration-manifests/deployments/zeromq-msg-proxy.yaml
+   Created -> $HOME/reana/configuration-manifests/namespaces/alice.yaml
+   Created -> $HOME/reana/configuration-manifests/namespaces/atlas.yaml
+   Created -> $HOME/reana/configuration-manifests/namespaces/cms.yaml
+   Created -> $HOME/reana/configuration-manifests/namespaces/lhcb.yaml
+   Created -> $HOME/reana/configuration-manifests/resourcequotas/alice-quota.yaml
+   Created -> $HOME/reana/configuration-manifests/resourcequotas/atlas-quota.yaml
+   Created -> $HOME/reana/configuration-manifests/resourcequotas/cms-quota.yaml
+   Created -> $HOME/reana/configuration-manifests/resourcequotas/lhcb-quota.yaml
+   Created -> $HOME/reana/configuration-manifests/services/job-controller.yaml
+   Created -> $HOME/reana/configuration-manifests/services/message-broker.yaml
+   Created -> $HOME/reana/configuration-manifests/services/workflow-controller.yaml
+   Created -> $HOME/reana/configuration-manifests/services/workflow-monitor.yaml
+   Created -> $HOME/reana/configuration-manifests/services/zeromq-msg-proxy.yaml
 
 
 Once it is done, a directory called `configuration-manifests` with the following structure should be available:


### PR DESCRIPTION
* Makes Getting Started example impersonal, using generic `$HOME` to indicate
  user home directory.

* Adds `mkvirtualenv` step and amends `pip` installation command output to
  better match the output of first-time installations.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>